### PR TITLE
Add int support

### DIFF
--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -27,6 +27,20 @@ defmodule ABI.TypeDecoder do
       ...>    )
       [69, true]
 
+      iex> "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd6"
+      ...> |> Base.decode16!(case: :lower)
+      ...> |> ABI.TypeDecoder.decode(
+      ...>      %ABI.FunctionSelector{
+      ...>        function: "baz",
+      ...>        types: [
+      ...>          {:int, 8}
+      ...>        ],
+      ...>        returns: :int
+      ...>      }
+      ...>    )
+      [-42]
+
+
       iex> "000000000000000000000000000000000000000000000000000000000000000b68656c6c6f20776f726c64000000000000000000000000000000000000000000"
       ...> |> Base.decode16!(case: :lower)
       ...> |> ABI.TypeDecoder.decode(
@@ -168,6 +182,10 @@ defmodule ABI.TypeDecoder do
     decode_uint(data, size_in_bits)
   end
 
+  defp decode_type({:int, size_in_bits}, data) do
+    decode_int(data, size_in_bits)
+  end
+
   defp decode_type(:address, data), do: decode_bytes(data, 20, :left)
 
   defp decode_type(:bool, data) do
@@ -256,6 +274,12 @@ defmodule ABI.TypeDecoder do
     total_bit_size = size_in_bits + ExthCrypto.Math.mod(256 - size_in_bits, 256)
 
     <<value::integer-size(total_bit_size), rest::binary>> = data
+
+    {value, rest}
+  end
+
+  defp decode_int(data, _size_in_bits) do
+    <<value::signed-256, rest::binary>> = data
 
     {value, rest}
   end

--- a/test/abi/type_decoder_test.exs
+++ b/test/abi/type_decoder_test.exs
@@ -1,4 +1,22 @@
 defmodule ABI.TypeDecoderTest do
   use ExUnit.Case, async: true
   doctest ABI.TypeDecoder
+
+  describe "decode/2 '{:int, size}' type" do
+    test "successfully decodes positives and negatives integers" do
+      positive_int = "000000000000000000000000000000000000000000000000000000000000002a"
+      negative_int = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd8f1"
+      result_to_decode = Base.decode16!(positive_int <> negative_int, case: :lower)
+      selector = %ABI.FunctionSelector{
+        function: "baz",
+        types: [
+          {:int, 8},
+          {:int, 256}
+        ],
+        returns: :int
+      }
+
+      assert ABI.TypeDecoder.decode(result_to_decode, selector) == [42, -9999]
+    end
+  end
 end

--- a/test/abi/type_encoder_test.exs
+++ b/test/abi/type_encoder_test.exs
@@ -1,4 +1,41 @@
 defmodule ABI.TypeEncoderTest do
   use ExUnit.Case, async: true
   doctest ABI.TypeEncoder
+
+  describe "encode/2 '{:int, size}' type" do
+    test "successfully encodes positive and negative values" do
+      data_to_encode = [42, -42]
+      selector = %ABI.FunctionSelector{
+        function: "baz",
+        types: [
+          {:int, 8},
+          {:int, 16}
+        ],
+        returns: :bool
+      }
+
+      encrypted_fn_name = "64ea0ab7"
+      positive_int = "000000000000000000000000000000000000000000000000000000000000002a" # 42
+      negative_int = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd6" # -42
+      expected_result = Base.decode16!(encrypted_fn_name <> positive_int <> negative_int, case: :lower)
+
+      assert ABI.TypeEncoder.encode(data_to_encode, selector) == expected_result
+    end
+
+    test "raises when there is signed integer overflow" do
+      # an 8 bit signed integer must be between -127 and 127
+      data_to_encode = [128]
+      selector = %ABI.FunctionSelector{
+        function: "baz",
+        types: [
+          {:int, 8}
+        ],
+        returns: :bool
+      }
+
+      assert_raise RuntimeError, fn ->
+        ABI.TypeEncoder.encode(data_to_encode, selector)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/ex_abi/issues/1 (originally: https://github.com/poanetwork/poa-explorer/issues/363).

## Description

The `int` type in Solidity differs from `uint` in which it includes negative numbers in its range of possible values. For instance, an 8-bit `int` can contain any number from -127 to 127, while an 8-bit `uint` can contain any number from 0 to 255. Also, if we try to define an 8-bit integer outside of those ranges, we will get an overflow (and possibly an error or unexpected behaviour from the machine that is running the code). Related resource on unsigned and signed integers: http://kias.dyndns.org/comath/13.html.

While this lib could handle `uint` types, it had no support for `int` types. This PR adds support for them, by enabling both encoding and decoding of `int` types in the `ABI.TypeEncoder` and `ABI.TypeDecoder`.