### PR TITLE
Add support for tuple type for inputs and outputs

### DIFF
--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -140,7 +140,13 @@ defmodule ABI.FunctionSelector do
 
   def parse_specification_item(_), do: nil
 
-  defp parse_specification_type(%{"type" => type}), do: decode_type(type)
+  @doc false
+  def parse_specification_type(%{"type" => "tuple", "components" => components}) do
+    sub_types = for component <- components, do: parse_specification_type(component)
+    {:tuple, sub_types}
+  end
+
+  def parse_specification_type(%{"type" => type}), do: decode_type(type)
 
   @doc """
   Decodes the given type-string as a single type.

--- a/test/abi/function_selector_test.exs
+++ b/test/abi/function_selector_test.exs
@@ -1,4 +1,70 @@
 defmodule ABI.FunctionSelectorTest do
   use ExUnit.Case, async: true
   doctest ABI.FunctionSelector
+
+  import ABI.FunctionSelector
+
+  describe "parse_specification_type/1" do
+    test "with a tuple and components" do
+      type = %{
+        "name" => "",
+        "type" => "tuple",
+        "components" => [
+          %{
+            "name" => "",
+            "type" => "uint256[6]"
+          },
+          %{
+            "name" => "",
+            "type" => "bool"
+          },
+          %{
+            "name" => "",
+            "type" => "uint256[24]"
+          },
+          %{
+            "name" => "",
+            "type" => "bool[24]"
+          },
+          %{
+            "name" => "",
+            "type" => "uint256"
+          },
+          %{
+            "name" => "",
+            "type" => "uint256"
+          },
+          %{
+            "name" => "",
+            "type" => "uint256"
+          },
+          %{
+            "name" => "",
+            "type" => "uint256"
+          },
+          %{
+            "name" => "",
+            "type" => "string"
+          }
+        ]
+      }
+
+      expected = {
+        :tuple,
+        [
+         {:array, {:uint, 256}, 6},
+         :bool,
+         {:array, {:uint, 256}, 24},
+         {:array, :bool, 24},
+         {:uint, 256},
+         {:uint, 256},
+         {:uint, 256},
+         {:uint, 256},
+         :string
+        ]
+      }
+
+      assert parse_specification_type(type) == expected
+    end
+  end
 end


### PR DESCRIPTION
Adds support for the `tuple` type defined in the [ABI](http://solidity.readthedocs.io/en/latest/abi-spec.html#handling-tuple-types) for inputs and outputs.

For example, here's an ABI using the `tuple` type:

```
[
  {
    "name": "foo",
    "type": "function",
    "outputs: [
      {
        "name": "",
        "type": "tuple",
        "components": [
          {
            "name": "",
            "type": "uint256"
          },
          {
            "name": "",
            "type": "uint256"
          }
        ]
      },
      {
        "name": "",
        "type": "uint256"
      }
    ],
    "inputs": []
  }
]
```

The output type for this function would be `{:tuple, [:uint256, :unit256]}`.