### PR TITLE
Allow functions to have mutliple output types

### DIFF
--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -87,8 +87,8 @@ defmodule ABI do
       iex> File.read!("priv/dog.abi.json")
       ...> |> Poison.decode!
       ...> |> ABI.parse_specification
-      [%ABI.FunctionSelector{function: "bark", returns: nil, types: [:address, :bool]},
-       %ABI.FunctionSelector{function: "rollover", returns: :bool, types: []}]
+      [%ABI.FunctionSelector{function: "bark", returns: [], types: [:address, :bool]},
+       %ABI.FunctionSelector{function: "rollover", returns: [:bool], types: []}]
 
       iex> [%{
       ...>   "constant" => true,
@@ -103,7 +103,7 @@ defmodule ABI do
       ...>   "type" => "function"
       ...> }]
       ...> |> ABI.parse_specification
-      [%ABI.FunctionSelector{function: "bark", returns: nil, types: [:address, :bool]}]
+      [%ABI.FunctionSelector{function: "bark", returns: [], types: [:address, :bool]}]
 
       iex> [%{
       ...>   "inputs" => [
@@ -122,7 +122,7 @@ defmodule ABI do
       ...>   "type" => "fallback"
       ...> }]
       ...> |> ABI.parse_specification
-      [%ABI.FunctionSelector{function: nil, returns: nil, types: []}]
+      [%ABI.FunctionSelector{function: nil, returns: [], types: []}]
   """
   def parse_specification(doc) do
     doc

--- a/lib/abi/parser.ex
+++ b/lib/abi/parser.ex
@@ -16,7 +16,7 @@ defmodule ABI.Parser do
 
     case ast do
       {:type, type} -> type
-      {:selector, selector_parts} -> struct!(ABI.FunctionSelector, selector_parts)
+      {:selector, selector_parts} -> ABI.FunctionSelector.from_params(selector_parts)
     end
   end
 end

--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -24,7 +24,7 @@ defmodule ABI.TypeDecoder do
       ...>          {:uint, 32},
       ...>          :bool
       ...>        ],
-      ...>        returns: :bool
+      ...>        returns: [:bool]
       ...>      }
       ...>    )
       [69, true]
@@ -37,7 +37,7 @@ defmodule ABI.TypeDecoder do
       ...>        types: [
       ...>          {:int, 8}
       ...>        ],
-      ...>        returns: :int
+      ...>        returns: [:int]
       ...>      }
       ...>    )
       [-42]

--- a/test/abi_test.exs
+++ b/test/abi_test.exs
@@ -1,4 +1,85 @@
 defmodule ABITest do
   use ExUnit.Case
   doctest ABI
+
+  import ABI
+
+  alias ABI.FunctionSelector
+
+  describe "parse_specification/1" do
+    test "parses an ABI" do
+      abi = [
+        %{
+          "constant" => true,
+          "inputs" => [
+            %{
+              "type" => "uint256",
+              "name" => ""
+            }
+          ],
+          "name" => "fooBar",
+          "outputs" => [
+            %{
+              "name" => "",
+              "type" => "uint256[6]"
+            },
+            %{
+              "name" => "",
+              "type" => "bool"
+            },
+            %{
+              "name" => "",
+              "type" => "uint256[3]"
+            },
+            %{
+              "name" => "",
+              "type" => "string"
+            }
+          ],
+          "payable" => false,
+          "type" => "function"
+        },
+        %{
+          "name" => "baz",
+          "type" => "function",
+          "outputs" => [
+            %{
+              "name" => "",
+              "type" => "tuple",
+              "components" => [
+                %{
+                  "name" => "",
+                  "type" => "uint256"
+                },
+                %{
+                  "name" => "",
+                  "type" => "uint256"
+                }
+              ]
+            },
+            %{
+              "name" => "",
+              "type" => "string"
+            }
+          ],
+          "inputs" => []
+        }
+      ]
+
+      expected = [
+        %FunctionSelector{
+          function: "fooBar",
+          types: [{:uint, 256}],
+          returns: [{:array, {:uint, 256}, 6}, :bool, {:array, {:uint, 256}, 3}, :string]
+        },
+        %FunctionSelector{
+          function: "baz",
+          types: [],
+          returns: [{:tuple, [{:uint, 256}, {:uint, 256}]}, :string]
+        }
+      ]
+
+      assert parse_specification(abi) == expected
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for a function to return multiple types of data. Before, only 1 type was expected for a return. Also, the results of a function are always returned as a list. If a function has no outputs, its value is simply `[]`.