### PR TITLE
feat: Add method_ids, tests and other utilities

### DIFF
--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -362,10 +362,4 @@ defmodule ABI.TypeDecoder do
         {value, rest}
     end
   end
-
-  defp nul_terminate_string(raw_string) do
-    raw_string = :erlang.iolist_to_binary(raw_string)
-    [pre_nul_part | _] = :binary.split(raw_string, <<0>>)
-    pre_nul_part
-  end
 end

--- a/test/abi_test.exs
+++ b/test/abi_test.exs
@@ -14,25 +14,25 @@ defmodule ABITest do
           "inputs" => [
             %{
               "type" => "uint256",
-              "name" => ""
+              "name" => "foo"
             }
           ],
           "name" => "fooBar",
           "outputs" => [
             %{
-              "name" => "",
+              "name" => "foo",
               "type" => "uint256[6]"
             },
             %{
-              "name" => "",
+              "name" => "bar",
               "type" => "bool"
             },
             %{
-              "name" => "",
+              "name" => "baz",
               "type" => "uint256[3]"
             },
             %{
-              "name" => "",
+              "name" => "buz",
               "type" => "string"
             }
           ],
@@ -42,6 +42,45 @@ defmodule ABITest do
         %{
           "name" => "baz",
           "type" => "function",
+          "outputs" => [
+            %{
+              "name" => "",
+              "type" => "tuple",
+              "components" => [
+                %{
+                  "name" => "foo",
+                  "type" => "uint256"
+                },
+                %{
+                  "name" => "bar",
+                  "type" => "uint256"
+                }
+              ]
+            },
+            %{
+              "name" => "",
+              "type" => "string"
+            }
+          ],
+          "inputs" => []
+        },
+        %{
+          "name" => "sam",
+          "type" => "function",
+          "inputs" => [
+            %{
+              "type" => "bytes",
+              "name" => "foo"
+            },
+            %{
+              "type" => "bool",
+              "name" => "bar"
+            },
+            %{
+              "type" => "uint256[]",
+              "name" => "baz"
+            }
+          ],
           "outputs" => [
             %{
               "name" => "",
@@ -61,21 +100,30 @@ defmodule ABITest do
               "name" => "",
               "type" => "string"
             }
-          ],
-          "inputs" => []
+          ]
         }
       ]
 
       expected = [
         %FunctionSelector{
           function: "fooBar",
+          input_names: ["foo"],
           types: [{:uint, 256}],
-          returns: [{:array, {:uint, 256}, 6}, :bool, {:array, {:uint, 256}, 3}, :string]
+          returns: [{:array, {:uint, 256}, 6}, :bool, {:array, {:uint, 256}, 3}, :string],
+          method_id: <<245, 72, 246, 70>>
         },
         %FunctionSelector{
           function: "baz",
           types: [],
-          returns: [{:tuple, [{:uint, 256}, {:uint, 256}]}, :string]
+          returns: [{:tuple, [{:uint, 256}, {:uint, 256}]}, :string],
+          method_id: <<167, 145, 111, 172>>
+        },
+        %FunctionSelector{
+          function: "sam",
+          input_names: ["foo", "bar", "baz"],
+          types: [:bytes, :bool, {:array, {:uint, 256}}],
+          returns: [{:tuple, [{:uint, 256}, {:uint, 256}]}, :string],
+          method_id: <<165, 100, 59, 242>>
         }
       ]
 


### PR DESCRIPTION
This adds a few things that I've needed for dealing with ABI decoding.

* Attaches the method id to the struct as `method_id`
* Adds the argument names to the struct as `input_names`
* Adds `encode_type/1` to give a public API for encoding single types (used for display in blockscout)
* Adds `find_and_decode/2` which finds the correct function selector from the list by method_id and decodes the provided call