### PR TITLE
Update .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.10.2
-erlang 22
+erlang 22.0


### PR DESCRIPTION
asdf fails with `22 is not a valid Erlang/OTP release`