### PR TITLE
change elixir version in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/ex_abi
     docker:
-      - image: elixir:latest
+      - image: elixir:1.11.4
         environment:
           MIX_ENV: test
 


### PR DESCRIPTION
it seems rustler doesn't support otp 24