### PR TITLE
Fix case typo in nonpayable state mutability

### DIFF
--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -118,7 +118,7 @@ defmodule ABI do
       ...> |> Jason.decode!
       ...> |> ABI.parse_specification
       ...> |> ABI.find_and_decode("b85d0bd200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16!(case: :lower))
-      {%ABI.FunctionSelector{type: :function, function: "bark", input_names: ["at", "loudly"], method_id: <<184, 93, 11, 210>>, returns: [], types: [:address, :bool]}, [<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1>>, true]}
+      {%ABI.FunctionSelector{type: :function, function: "bark", input_names: ["at", "loudly"], method_id: <<184, 93, 11, 210>>, returns: [], types: [:address, :bool], state_mutability: :non_payable}, [<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1>>, true]}
   """
   def find_and_decode(function_selectors, data, data_type \\ :input) do
     with {:ok, method_id, _rest} <- Util.split_method_id(data),
@@ -145,8 +145,8 @@ defmodule ABI do
       iex> File.read!("priv/dog.abi.json")
       ...> |> Jason.decode!
       ...> |> ABI.parse_specification
-      [%ABI.FunctionSelector{type: :function, function: "bark", input_names: ["at", "loudly"], method_id: <<184, 93, 11, 210>>, returns: [], types: [:address, :bool]},
-       %ABI.FunctionSelector{type: :function, function: "rollover", method_id: <<176, 86, 180, 154>>, returns: [:bool], types: []}]
+      [%ABI.FunctionSelector{type: :function, function: "bark", input_names: ["at", "loudly"], method_id: <<184, 93, 11, 210>>, returns: [], types: [:address, :bool], state_mutability: :non_payable},
+       %ABI.FunctionSelector{type: :function, function: "rollover", method_id: <<176, 86, 180, 154>>, returns: [:bool], types: [], state_mutability: :non_payable}]
 
       iex> [%{
       ...>   "constant" => true,
@@ -161,7 +161,7 @@ defmodule ABI do
       ...>   "type" => "function"
       ...> }]
       ...> |> ABI.parse_specification
-      [%ABI.FunctionSelector{type: :function, function: "bark", method_id: <<184, 93, 11, 210>>, input_names: ["at", "loudly"], returns: [], types: [:address, :bool]}]
+      [%ABI.FunctionSelector{type: :function, function: "bark", method_id: <<184, 93, 11, 210>>, input_names: ["at", "loudly"], returns: [], types: [:address, :bool], state_mutability: :non_payable}]
 
       iex> [%{
       ...>   "inputs" => [

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -68,10 +68,10 @@ defmodule ABI.FunctionSelector do
     "tuple"
   ]
 
-  @state_mutability %{
+  @state_mutabilities %{
     "pure" => :pure,
     "view" => :view,
-    "nonPayable" => :non_payable,
+    "nonpayable" => :non_payable,
     "payable" => :payable
   }
 
@@ -190,7 +190,7 @@ defmodule ABI.FunctionSelector do
         types: input_types,
         returns: output_types,
         input_names: input_names,
-        state_mutability: @state_mutability[item["stateMutability"]],
+        state_mutability: @state_mutabilities[item["stateMutability"]],
         type: :function
       }
 

--- a/test/abi/function_selector_test.exs
+++ b/test/abi/function_selector_test.exs
@@ -345,7 +345,7 @@ defmodule ABI.FunctionSelectorTest do
     end
 
     test "with stateMutability set" do
-      ~w(pure view nonPayable payable)
+      ~w(pure view nonpayable payable)
       |> Enum.zip(~w(pure view non_payable payable)a)
       |> Enum.each(fn {state_mutability, state_mutability_atom} ->
         function = %{


### PR DESCRIPTION
Hello,

Sorry but according to [this](https://docs.soliditylang.org/en/v0.6.0/abi-spec.html) I have used `nonPayable` instead of `nonpayable` as the state mutability input from the ABI spec. It's now fixed.

I think `nonPayable` (with capital P) was never used in ABI specs but please double check and let me know if I'm wrong.

Sorry for the inconvenience and thank you for your great work.