### PR TITLE
Handle Events with same topic hash properly

### DIFF
--- a/lib/abi/event.ex
+++ b/lib/abi/event.ex
@@ -68,11 +68,10 @@ defmodule ABI.Event do
           {FunctionSelector.t(), [event_value]} | {:error, any}
   def find_and_decode(function_selectors, topic1, topic2, topic3, topic4, data) do
     input_topics = [topic2, topic3, topic4]
-    topics_length = Enum.count(input_topics, fn x -> x != nil end)
 
     with {:ok, method_id, _rest} <- Util.split_method_id(topic1),
          {:ok, selector} when not is_nil(selector) <-
-           Util.find_selector_by_event_id(function_selectors, method_id, topics_length) do
+           Util.find_selector_by_event_id(function_selectors, method_id, input_topics) do
       args = Enum.zip([selector.input_names, selector.types, selector.inputs_indexed])
 
       {indexed_args, unindexed_args} =

--- a/lib/abi/event.ex
+++ b/lib/abi/event.ex
@@ -67,11 +67,12 @@ defmodule ABI.Event do
   @spec find_and_decode([FunctionSelector.t()], topic, topic, topic, topic, binary) ::
           {FunctionSelector.t(), [event_value]} | {:error, any}
   def find_and_decode(function_selectors, topic1, topic2, topic3, topic4, data) do
+    input_topics = [topic2, topic3, topic4]
+    topics_length = Enum.count(input_topics, fn x -> x != nil end)
+
     with {:ok, method_id, _rest} <- Util.split_method_id(topic1),
          {:ok, selector} when not is_nil(selector) <-
-           Util.find_selector_by_method_id(function_selectors, method_id) do
-      input_topics = [topic2, topic3, topic4]
-
+           Util.find_selector_by_event_id(function_selectors, method_id, topics_length) do
       args = Enum.zip([selector.input_names, selector.types, selector.inputs_indexed])
 
       {indexed_args, unindexed_args} =

--- a/lib/abi/util.ex
+++ b/lib/abi/util.ex
@@ -21,4 +21,24 @@ defmodule ABI.Util do
       {:error, :no_matching_function}
     end
   end
+
+  def find_selector_by_event_id(function_selectors, method_id_target, topics_length) do
+    # Only process function selectors that are of type event
+    function_selector =
+      Enum.find(function_selectors, fn
+        %{type: :event, method_id: ^method_id_target, inputs_indexed: inputs_indexed} ->
+          # match the length of topics and indexed_args_length
+          indexed_length = Enum.count(inputs_indexed, &(&1 == true))
+          topics_length == indexed_length
+
+        _ ->
+          false
+      end)
+
+    if function_selector do
+      {:ok, function_selector}
+    else
+      {:error, :no_matching_function}
+    end
+  end
 end

--- a/lib/abi/util.ex
+++ b/lib/abi/util.ex
@@ -23,12 +23,12 @@ defmodule ABI.Util do
   end
 
   def find_selector_by_event_id(function_selectors, method_id_target, input_topics) do
+    # match the length of topics and indexed_args_length
+    topics_length = Enum.count(input_topics, fn x -> x != nil end)
     # Only process function selectors that are of type event
     function_selector =
       Enum.find(function_selectors, fn
         %{type: :event, method_id: ^method_id_target, inputs_indexed: inputs_indexed} ->
-          # match the length of topics and indexed_args_length
-          topics_length = Enum.count(input_topics, fn x -> x != nil end)
           indexed_length = Enum.count(inputs_indexed, &(&1 == true))
           topics_length == indexed_length
 

--- a/lib/abi/util.ex
+++ b/lib/abi/util.ex
@@ -22,12 +22,13 @@ defmodule ABI.Util do
     end
   end
 
-  def find_selector_by_event_id(function_selectors, method_id_target, topics_length) do
+  def find_selector_by_event_id(function_selectors, method_id_target, input_topics) do
     # Only process function selectors that are of type event
     function_selector =
       Enum.find(function_selectors, fn
         %{type: :event, method_id: ^method_id_target, inputs_indexed: inputs_indexed} ->
           # match the length of topics and indexed_args_length
+          topics_length = Enum.count(input_topics, fn x -> x != nil end)
           indexed_length = Enum.count(inputs_indexed, &(&1 == true))
           topics_length == indexed_length
 

--- a/test/abi/util_test.exs
+++ b/test/abi/util_test.exs
@@ -1,0 +1,43 @@
+defmodule ABI.UtilTest do
+  use ExUnit.Case, async: true
+
+  @selectors [
+    %ABI.FunctionSelector{
+      function: "Transfer",
+      method_id: <<221, 242, 82, 173>>,
+      type: :event,
+      inputs_indexed: [false, false, false],
+      state_mutability: nil,
+      input_names: ["from", "to", "tokenId"],
+      types: [:address, :address, {:uint, 256}],
+      returns: []
+    },
+    %ABI.FunctionSelector{
+      function: "Transfer",
+      method_id: <<221, 242, 82, 173>>,
+      type: :event,
+      inputs_indexed: [true, true, true],
+      state_mutability: nil,
+      input_names: ["from", "to", "tokenId"],
+      types: [:address, :address, {:uint, 256}],
+      returns: []
+    }
+  ]
+
+  describe "decode events" do
+    test "successfully decodes ERC721 transfer event" do
+      {:ok, selector} =
+        ABI.Util.find_selector_by_event_id(@selectors, <<221, 242, 82, 173>>, [
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 230, 218, 29, 25, 253, 206, 193, 121, 186, 151,
+            85, 242, 198, 19, 159, 143, 254, 203, 254, 176>>,
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 168, 47, 182, 247, 249, 220, 207, 188, 171, 157,
+            153, 173, 222, 184, 132, 3, 58, 241, 27, 134>>,
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 12, 12>>
+        ])
+
+      assert selector.function == "Transfer"
+      assert selector.inputs_indexed == [true, true, true]
+    end
+  end
+end

--- a/test/abi/util_test.exs
+++ b/test/abi/util_test.exs
@@ -21,6 +21,16 @@ defmodule ABI.UtilTest do
       input_names: ["from", "to", "tokenId"],
       types: [:address, :address, {:uint, 256}],
       returns: []
+    },
+    %ABI.FunctionSelector{
+      function: "OwnershipTransferred",
+      method_id: <<139, 224, 7, 156>>,
+      type: :event,
+      inputs_indexed: [true, true],
+      state_mutability: nil,
+      input_names: ["previousOwner", "newOwner"],
+      types: [:address, :address],
+      returns: []
     }
   ]
 
@@ -38,6 +48,20 @@ defmodule ABI.UtilTest do
 
       assert selector.function == "Transfer"
       assert selector.inputs_indexed == [true, true, true]
+    end
+
+    test "decode OwnershipTransferred event" do
+      {:ok, selector} =
+        ABI.Util.find_selector_by_event_id(@selectors, <<139, 224, 7, 156>>, [
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0>>,
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 79, 181, 74, 58, 157, 2, 63, 219, 87, 69, 216,
+            158, 228, 106, 170, 82, 18, 171, 87, 125>>,
+          nil
+        ])
+
+      assert selector.function == "OwnershipTransferred"
+      assert selector.inputs_indexed == [true, true]
     end
   end
 end


### PR DESCRIPTION
I added more context regarding events that have same topic but different indexed arguments [here](https://github.com/poanetwork/ex_abi/issues/114)

This change allows the library to handle Transfer event that has multiple variants of arguments properly.

`Transfer(address from, address to, uint256 tokenId)`
`Transfer(address indexed from, address indexed to, uint256 indexed  tokenId)`
`Transfer(address indexed from, address indexed to, uint256  tokenId)`

This change is creating a different function for an Event to check that number of Topics should be equal to the length of the indexed arguments.
