### PR TITLE
Address `Logger.warn` deprecation

### DIFF
--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -284,7 +284,7 @@ defmodule ABI.FunctionSelector do
         simple_types?(types, item)
 
       false ->
-        Logger.warn("Can not parse #{inspect(item)} because it contains complex types")
+        Logger.warning("Can not parse #{inspect(item)} because it contains complex types")
         false
     end
   end
@@ -300,7 +300,7 @@ defmodule ABI.FunctionSelector do
         simple_types?(types, item)
 
       false ->
-        Logger.warn("Can not parse #{inspect(item)} because it contains complex types")
+        Logger.warning("Can not parse #{inspect(item)} because it contains complex types")
         false
     end
   end


### PR DESCRIPTION
The Logger.warn macro is now deprecated in favour of Logger.warning 

https://hexdocs.pm/logger/1.12.3/Logger.html#warn/2