### PR TITLE
Add return_names to `FunctionSelector` struct

### DIFF
--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -146,7 +146,7 @@ defmodule ABI do
       ...> |> Jason.decode!
       ...> |> ABI.parse_specification
       [%ABI.FunctionSelector{type: :function, function: "bark", input_names: ["at", "loudly"], method_id: <<184, 93, 11, 210>>, returns: [], types: [:address, :bool], state_mutability: :non_payable},
-       %ABI.FunctionSelector{type: :function, function: "rollover", method_id: <<176, 86, 180, 154>>, returns: [:bool], types: [], state_mutability: :non_payable}]
+       %ABI.FunctionSelector{type: :function, function: "rollover", method_id: <<176, 86, 180, 154>>, returns: [:bool], return_names: ["is_a_good_boy"], types: [], state_mutability: :non_payable}]
 
       iex> [%{
       ...>   "constant" => true,

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -28,6 +28,7 @@ defmodule ABI.FunctionSelector do
   * `:function` - Name of the function
   * `:types` - Function's input types
   * `:returns` - Function's return types
+  * `:return_names` - Names of the return values (output names)
   * `:method_id` - First four bits of the hashed function signature
   * `:input_names` - Names of the input values (argument names)
   * `:type` - The type of the selector. Events are part of the ABI, but are not considered functions
@@ -39,6 +40,7 @@ defmodule ABI.FunctionSelector do
           input_names: [String.t()],
           types: [type],
           returns: [type],
+          return_names: [String.t()],
           type: :event | :function | :constructor | :error,
           state_mutability: :pure | :view | :non_payable | :payable | nil,
           inputs_indexed: [boolean]
@@ -52,7 +54,8 @@ defmodule ABI.FunctionSelector do
     :state_mutability,
     input_names: [],
     types: [],
-    returns: []
+    returns: [],
+    return_names: []
   ]
 
   @simple_types [
@@ -184,11 +187,13 @@ defmodule ABI.FunctionSelector do
       input_names = Enum.map(named_inputs, &Map.get(&1, "name"))
 
       output_types = Enum.map(named_outputs, &parse_specification_type/1)
+      output_names = Enum.map(named_outputs, &Map.get(&1, "name"))
 
       selector = %ABI.FunctionSelector{
         function: function_name,
         types: input_types,
         returns: output_types,
+        return_names: output_names,
         input_names: input_names,
         state_mutability: @state_mutabilities[item["stateMutability"]],
         type: :function
@@ -268,6 +273,7 @@ defmodule ABI.FunctionSelector do
       input_names: [],
       types: [],
       returns: [],
+      return_names: [],
       type: :function
     }
   end

--- a/test/abi/function_selector_test.exs
+++ b/test/abi/function_selector_test.exs
@@ -104,6 +104,7 @@ defmodule ABI.FunctionSelectorTest do
                  inputs_indexed: nil,
                  method_id: <<33, 173, 158, 39>>,
                  returns: [uint: 256],
+                 return_names: ["totalAmountIn"],
                  type: :function,
                  types: [array: {:array, {:tuple, [uint: 256, uint: 256]}}],
                  state_mutability: :payable

--- a/test/abi_test.exs
+++ b/test/abi_test.exs
@@ -111,6 +111,7 @@ defmodule ABITest do
           input_names: ["foo"],
           types: [{:uint, 256}],
           returns: [{:array, {:uint, 256}, 6}, :bool, {:array, {:uint, 256}, 3}, :string],
+          return_names: ["foo", "bar", "baz", "buz"],
           method_id: <<245, 72, 246, 70>>
         },
         %FunctionSelector{
@@ -118,6 +119,7 @@ defmodule ABITest do
           function: "baz",
           types: [],
           returns: [{:tuple, [{:uint, 256}, {:uint, 256}]}, :string],
+          return_names: ["", ""],
           method_id: <<167, 145, 111, 172>>
         },
         %FunctionSelector{
@@ -126,6 +128,7 @@ defmodule ABITest do
           input_names: ["foo", "bar", "baz"],
           types: [:bytes, :bool, {:array, {:uint, 256}}],
           returns: [{:tuple, [{:uint, 256}, {:uint, 256}]}, :string],
+          return_names: ["", ""],
           method_id: <<165, 100, 59, 242>>
         }
       ]


### PR DESCRIPTION
This adds `return_names` just like `input_names` to the `ABI.FunctionSelector` struct.

Use case: I needed the names of the function outputs to include in the [Ethers library](https://github.com/alisinabh/elixir_ethers) when generating function documentations and inspecting them.