### PR TITLE
Fix parsing when function ABI is missing the `outputs` field

### DIFF
--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -182,8 +182,28 @@ defmodule ABI.FunctionSelector do
            "outputs" => named_outputs
          } <-
            item
-           # Workaround for missing "outputs" field.
-           # This is a fix for https://github.com/poanetwork/ex_abi/issues/162
+           # Workaround for ABIs that are missing the "outputs" field.
+           #
+           # For instance, consider this valid ABI:
+           #
+           # ```jsonc
+           # // ...
+           #     {
+           #         "type": "function",
+           #         "stateMutability": "view",
+           #         "name": "assumeLastTokenIdMatches",
+           #         "inputs": [
+           #             {
+           #                 "type": "uint256",
+           #                 "name": "lastTokenId",
+           #                 "internalType": "uint256"
+           #             }
+           #         ]
+           #     },
+           # // ...
+           # ```
+           # If the "outputs" field is missing, we should assume it's an empty
+           # list to continue parsing the ABI.
            |> Map.put_new("outputs", []),
          true <- simple_types?(named_inputs, item),
          true <- simple_types?(named_outputs, item) do

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -180,7 +180,11 @@ defmodule ABI.FunctionSelector do
            "name" => function_name,
            "inputs" => named_inputs,
            "outputs" => named_outputs
-         } <- item,
+         } <-
+           item
+           # Workaround for missing "outputs" field.
+           # This is a fix for https://github.com/poanetwork/ex_abi/issues/162
+           |> Map.put_new("outputs", []),
          true <- simple_types?(named_inputs, item),
          true <- simple_types?(named_outputs, item) do
       input_types = Enum.map(named_inputs, &parse_specification_type/1)

--- a/test/abi/function_selector_test.exs
+++ b/test/abi/function_selector_test.exs
@@ -113,7 +113,8 @@ defmodule ABI.FunctionSelectorTest do
     end
 
     @doc """
-    Regression test for issue #162 (https://github.com/poanetwork/ex_abi/issues/162).
+    Regression test to verify the correct parsing of ABIs that lack the
+    "outputs" field.
     """
     test "with the missing outputs field" do
       abi = [

--- a/test/abi/function_selector_test.exs
+++ b/test/abi/function_selector_test.exs
@@ -111,6 +111,42 @@ defmodule ABI.FunctionSelectorTest do
                }
              ] == ABI.parse_specification([abi])
     end
+
+    @doc """
+    Regression test for issue #162 (https://github.com/poanetwork/ex_abi/issues/162).
+    """
+    test "with the missing outputs field" do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "name" => "assumeLastTokenIdMatches",
+          "inputs" => [
+            %{
+              "type" => "uint256",
+              "name" => "lastTokenId",
+              "internalType" => "uint256"
+            }
+          ]
+        }
+      ]
+
+      expected = [
+        %FunctionSelector{
+          type: :function,
+          function: "assumeLastTokenIdMatches",
+          input_names: ["lastTokenId"],
+          types: [uint: 256],
+          returns: [],
+          return_names: [],
+          method_id: <<231, 40, 120, 180>>,
+          inputs_indexed: nil,
+          state_mutability: :view
+        }
+      ]
+
+      assert ABI.parse_specification(abi) == expected
+    end
   end
 
   describe "parse_specification_item/1" do


### PR DESCRIPTION
Closes #162. 