### PR TITLE
make keccak module configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/ex_abi](https://hexdocs.pm/ex_abi).
 
+## Confiiguration
+
+The default keccak library is set to `ex_keccak` but that can be ovveriden for a different libary:
+
+```elixir
+config :ex_abi, keccak_module: KeccakEx
+```
+
 ## Usage
 
 ### Encoding

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -403,8 +403,9 @@ defmodule ABI.FunctionSelector do
 
   defp add_method_id(selector) do
     signature = encode(selector)
+    keccak_module = Application.get_env(:ex_abi, :keccak_module, ExKeccak)
 
-    case ExKeccak.hash_256(signature) do
+    case keccak_module.hash_256(signature) do
       <<method_id::binary-size(4), _::binary>> ->
         %{selector | method_id: method_id}
 
@@ -414,9 +415,10 @@ defmodule ABI.FunctionSelector do
   end
 
   defp add_event_id(selector) do
+    keccak_module = Application.get_env(:ex_abi, :keccak_module, ExKeccak)
     signature = encode(selector)
 
-    %{selector | method_id: ExKeccak.hash_256(signature)}
+    %{selector | method_id: keccak_module.hash_256(signature)}
   end
 
   defp get_types(function_selector) do

--- a/lib/abi/type_encoder.ex
+++ b/lib/abi/type_encoder.ex
@@ -244,11 +244,12 @@ defmodule ABI.TypeEncoder do
   defp encode_method_id(%FunctionSelector{function: nil}), do: ""
 
   defp encode_method_id(function_selector) do
+    keccak_module = Application.get_env(:ex_abi, :keccak_module, ExKeccak)
     # Encode selector e.g. "baz(uint32,bool)" and take keccak
     kec =
       function_selector
       |> FunctionSelector.encode()
-      |> ExKeccak.hash_256()
+      |> keccak_module.hash_256()
 
     # Take first four bytes
     <<init::binary-size(4), _rest::binary>> = kec

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule ABI.Mixfile do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.24", only: :dev, runtime: false},
       {:jason, "~> 1.4"},
-      {:ex_keccak, "~> 0.7.5"},
+      {:ex_keccak, "~> 0.7.5", optional: true},
       {:propcheck, "~> 1.4", only: [:test, :dev]}
     ]
   end


### PR DESCRIPTION
I am building a project using [ethers](https://github.com/ExWeb3/elixir_ethers) that relies on `ex_abi`. I am having a challenge with the ExKeccak library using it with nerves. Ethers allow for a different library to be used but `ex_abi` uses `ExKeccak`, this PR is to make the keccak library used by ex_abi configurable.